### PR TITLE
Add instructions for version and group properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ POM_DEVELOPER_NAME=Chris Banes
 
 The `VERSION_NAME` value is important. If it contains the keyword `SNAPSHOT` then the build will upload to the snapshot server, if not then to the release server.
 
+Add the following lines to the project root build.gradle to read the version and group properties:
+
+```
+allprojects {
+    version = VERSION_NAME
+    group = GROUP
+}
+```
+
 ### 4. Create gradle.properties in each sub-project
 The values in this file are specific to the sub-project (and override those in the root `gradle.properties`). In this example, this is just the name, artifactId and packaging type:
 


### PR DESCRIPTION
You might want to lay it out differently but I think users would find it helpful to know how the group and version are set.

In addition some instructions about signing properties would be useful. I found Gabriele Mariotti's blog post helpful http://gmariotti.blogspot.com/2013/09/publish-aar-file-to-maven-central-with.html but some pointers in your README could save some time. Thoughts? I can send another PR for this.
