### PR TITLE
Update blog post URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 gradle-mvn-push
 ===============
 
-See this blog post for more context on this 'library': [http://chris.banes.me/blog/2013/08/27/pushing-aars-to-maven-central/]().
+See this blog post for more context on this 'library': [http://chris.banes.me/blog/2013/08/27/pushing-aars-to-maven-central/](http://chris.banes.me/blog/2013/08/27/pushing-aars-to-maven-central/).
 
 
 ## Usage


### PR DESCRIPTION
Leaving the URL empty in GitHub MarkDown links to the page it's displayed on.

(Sorry for the newline at the end, that's GitHub's inline text editor. :()
