### PR TITLE
Dependency between androidJavadocsJar and androidJavadocs

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -94,7 +94,7 @@ afterEvaluate { project ->
         source = android.sourceSets.main.allJava
     }
 
-    task androidJavadocsJar(type: Jar) {
+    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
         classifier = 'javadoc'
         from androidJavadocs.destinationDir
     }


### PR DESCRIPTION
So that when you use the uploadArchives task, the Javadocs gets generated.
