### PR TITLE
Removed redundancy while setting vars

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -18,7 +18,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 def isReleaseBuild() {
-    return version.contains("SNAPSHOT") == false
+    return VERSION_NAME.contains("SNAPSHOT") == false
 }
 
 def getReleaseRepositoryUrl() {
@@ -45,7 +45,9 @@ afterEvaluate { project ->
             mavenDeployer {
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
+                pom.groupId = GROUP
                 pom.artifactId = POM_ARTIFACT_ID
+                pom.version = VERSION_NAME
 
                 repository(url: getReleaseRepositoryUrl()) {
                     authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())


### PR DESCRIPTION
The README had most of the steps right, but it assumed that you set
the variables "group" and "version" in your build.gradle.  I've set
it up now so that this isn't necessary; you can just use VERSION_NAME
and GROUP without the middle man.
- Use "VERSION_NAME" instead of "version" for checking snapshot status
- Explicitly set groupId/version from GROUP and VERSION_NAME instead
  of assuming that group/version has been set previously.
