### PR TITLE
Fix androidJavadocs

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -93,7 +93,7 @@ afterEvaluate { project ->
     }
 
     task androidJavadocs(type: Javadoc) {
-        source = android.sourceSets.main.java
+        source = android.sourceSets.main.java.srcDirs
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     }
 


### PR DESCRIPTION
`androidJavadocs` currently fails with the following error and generates an empty javadoc.jar:

`Converting class com.android.build.gradle.internal.api.DefaultAndroidSourceDirectorySet to File using toString() method has been deprecated and is scheduled to be removed in Gradle 2.0. Please use java.io.File, java.lang.String, java.net.URL, or java.net.URI instead.`

This PR fixes this error and generates a correct javadoc.jar.
