### PR TITLE
Add properties getters to use gradle.build values

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,10 @@ signing.secretKeyRingFile=~/.gnupg/secring.gpg
 You may already have this file, in which case just edit the original. This file should contain the POM values which are common to all of your sub-project (if you have any). For instance, here's [ActionBar-PullToRefresh's](https://github.com/chrisbanes/ActionBar-PullToRefresh):
 
 ```properties
-VERSION_NAME=0.9.2-SNAPSHOT
-VERSION_CODE=92
-GROUP=com.github.chrisbanes.actionbarpulltorefresh
-
 POM_DESCRIPTION=A modern implementation of the pull-to-refresh for Android
 POM_URL=https://github.com/chrisbanes/ActionBar-PullToRefresh
-POM_SCM_URL=https://github.com/chrisbanes/ActionBar-PullToRefresh
 POM_SCM_CONNECTION=scm:git@github.com:chrisbanes/ActionBar-PullToRefresh.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:chrisbanes/ActionBar-PullToRefresh.git
+
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
@@ -44,15 +39,12 @@ POM_DEVELOPER_ID=chrisbanes
 POM_DEVELOPER_NAME=Chris Banes
 ```
 
-The `VERSION_NAME` value is important. If it contains the keyword `SNAPSHOT` then the build will upload to the snapshot server, if not then to the release server.
-
 ### 4. Create gradle.properties in each sub-project
 The values in this file are specific to the sub-project (and override those in the root `gradle.properties`). In this example, this is just the name, artifactId and packaging type:
 
 ```properties
 POM_NAME=ActionBar-PullToRefresh Library
 POM_ARTIFACT_ID=library
-POM_PACKAGING=aar
 ```
 
 ### 5. Call the script from each sub-modules build.gradle
@@ -76,10 +68,19 @@ $ gradle clean build uploadArchives
 There are other properties which can be set:
 
 ```
+GROUP (default is packageName)
+VERSION_NAME (default is build.gradle versionName)
+VERSION_CODE (default is build.gradle versionCode)
+POM_SCM_URL (default is POM_URL value)
+POM_SCM_DEV_CONNECTION (default is POM_SCM_CONNECTION value)
+
+POM_PACKAGING (default is "aar")
+
 RELEASE_REPOSITORY_URL (defaults to Maven Central's staging server)
 SNAPSHOT_REPOSITORY_URL (defaults to Maven Central's snapshot server)
 ```
 
+If `VERSION_NAME` value contains the keyword `SNAPSHOT` then the build will upload to the snapshot server, if not then to the release server.
 ## License
 
     Copyright 2013 Chris Banes

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -18,7 +18,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 def isReleaseBuild() {
-    return VERSION_NAME.contains("SNAPSHOT") == false
+    return getPomVersionName().contains("SNAPSHOT") == false
 }
 
 def getReleaseRepositoryUrl() {
@@ -39,15 +39,151 @@ def getRepositoryPassword() {
     return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
 }
 
+def getPomGroupId() {
+    if (hasProperty('GROUP')){
+        return GROUP
+    }else if (android.libraryVariants != null && android.libraryVariants.size() > 0){
+        return android.libraryVariants[0].applicationId
+    }else if (android.applicationVariants != null && android.applicationVariants.size() > 0){
+        return android.applicationVariants[0].applicationId
+    }else{
+        throw new InvalidUserDataException("You must set GROUP in gradle.properties file.")
+    }
+}
+
+def getPomArtifactId() {
+    if (hasProperty('POM_ARTIFACT_ID')){
+        return POM_ARTIFACT_ID
+    }else{
+        throw new InvalidUserDataException("You must set POM_ARTIFACT_ID in gradle.properties file.")
+    }
+}
+
+def getPomVersionName() {
+    if (hasProperty('VERSION_NAME')){
+        return VERSION_NAME
+    }else if ( android.defaultConfig.versionName != null){
+        return android.defaultConfig.versionName
+    }else{
+        throw new InvalidUserDataException("You must set VERSION_NAME in gradle.properties file.")
+    }
+}
+
+def getPomVersionCode() {
+    if (hasProperty('VERSION_CODE')){
+        return VERSION_CODE
+    }else if ( android.defaultConfig.versionCode != null){
+        return android.defaultConfig.versionCode
+    }else{
+        throw new InvalidUserDataException("You must set VERSION_CODE in gradle.properties file.")
+    }
+}
+
+def getPomPackaging() {
+    if (hasProperty('POM_PACKAGING')){
+        return POM_PACKAGING
+    }else{
+        return "aar"
+    }
+}
+
+def getPomName() {
+    if (hasProperty('POM_NAME')){
+        return POM_NAME
+    }else{
+        throw new InvalidUserDataException("You must set POM_NAME in gradle.properties file.")
+    }
+}
+
+def getPomDescription() {
+    if (hasProperty('POM_DESCRIPTION')){
+        return POM_DESCRIPTION
+    }else{
+        throw new InvalidUserDataException("You must set POM_DESCRIPTION in gradle.properties file.")
+    }
+}
+
+def getPomUrl() {
+    if (hasProperty('POM_URL')){
+        return POM_URL
+    }else{
+        throw new InvalidUserDataException("You must set POM_URL in gradle.properties file.")
+    }
+}
+
+def getPomScmUrl() {
+    if (hasProperty('POM_SCM_URL')){
+        return POM_SCM_URL
+    }else{
+        return getPomUrl();
+    }
+}
+
+def getPomScmConnection() {
+    if (hasProperty('POM_SCM_CONNECTION')){
+        return POM_SCM_CONNECTION
+    }else{
+        throw new InvalidUserDataException("You must set POM_SCM_CONNECTION in gradle.properties file.")
+    }
+}
+
+def getPomScmDevConnection() {
+    if (hasProperty('POM_SCM_DEV_CONNECTION')){
+        return POM_SCM_DEV_CONNECTION
+    }else{
+        return getPomScmConnection();
+    }
+}
+
+def getPomLicenseName() {
+    if (hasProperty('POM_LICENCE_NAME')){
+        return POM_LICENCE_NAME
+    }else{
+        throw new InvalidUserDataException("You must set POM_LICENCE_NAME in gradle.properties file.")
+    }
+}
+
+def getPomLicenseUrl() {
+    if (hasProperty('POM_LICENCE_URL')){
+        return POM_LICENCE_URL
+    }else{
+        throw new InvalidUserDataException("You must set POM_LICENCE_URL in gradle.properties file.")
+    }
+}
+
+def getPomLicenseDist() {
+    if (hasProperty('POM_LICENCE_DIST')){
+        return POM_LICENCE_DIST
+    }else{
+        throw new InvalidUserDataException("You must set POM_LICENCE_DIST in gradle.properties file.")
+    }
+}
+
+def getDeveloperId() {
+    if (hasProperty('POM_DEVELOPER_ID')){
+        return POM_DEVELOPER_ID
+    }else{
+        throw new InvalidUserDataException("You must set POM_DEVELOPER_ID in gradle.properties file.")
+    }
+}
+
+def getDeveloperName() {
+    if (hasProperty('POM_DEVELOPER_NAME')){
+        return POM_DEVELOPER_NAME
+    }else{
+        throw new InvalidUserDataException("You must set POM_DEVELOPER_NAME in gradle.properties file.")
+    }
+}
+
 afterEvaluate { project ->
     uploadArchives {
         repositories {
             mavenDeployer {
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-                pom.groupId = GROUP
-                pom.artifactId = POM_ARTIFACT_ID
-                pom.version = VERSION_NAME
+                pom.groupId = getPomGroupId()
+                pom.artifactId = getPomArtifactId()
+                pom.version = getPomVersionName()
 
                 repository(url: getReleaseRepositoryUrl()) {
                     authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
@@ -56,30 +192,43 @@ afterEvaluate { project ->
                     authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
                 }
 
+                def pomName = getPomName()
+                def pomPackaging = getPomPackaging()
+                def pomDescription = getPomDescription()
+                def pomUrl = getPomUrl()
+                def pomScmUrl = getPomScmUrl()
+                def pomScmConnection = getPomScmConnection()
+                def pomScmDevConnection = getPomScmDevConnection()
+                def pomLicenseName = getPomLicenseName()
+                def pomLicenseUrl = getPomLicenseUrl()
+                def pomDistribution = getPomLicenseDist()
+                def pomDeveloperId = getDeveloperId()
+                def pomDeveloperName = getDeveloperName()
+
                 pom.project {
-                    name POM_NAME
-                    packaging POM_PACKAGING
-                    description POM_DESCRIPTION
-                    url POM_URL
+                    name pomName
+                    packaging pomPackaging
+                    description pomDescription
+                    url pomUrl
 
                     scm {
-                        url POM_SCM_URL
-                        connection POM_SCM_CONNECTION
-                        developerConnection POM_SCM_DEV_CONNECTION
+                        url pomScmUrl
+                        connection pomScmConnection
+                        developerConnection pomScmDevConnection
                     }
 
                     licenses {
                         license {
-                            name POM_LICENCE_NAME
-                            url POM_LICENCE_URL
-                            distribution POM_LICENCE_DIST
+                            name pomLicenseName
+                            url pomLicenseUrl
+                            distribution pomDistribution
                         }
                     }
 
                     developers {
                         developer {
-                            id POM_DEVELOPER_ID
-                            name POM_DEVELOPER_NAME
+                            id pomDeveloperId
+                            name pomDeveloperName
                         }
                     }
                 }


### PR DESCRIPTION
No breaking changes !

If GROUP is not set, use packageName
If VERSION_NAME is not set, use build.gradle versionName
If VERSION_CODE is not set, use build.gradle versionCode
If POM_SCM_URL is not set, use POM_URL
If POM_SCM_DEV_CONNECTION is not set, use POM_SCM_CONNECTION
If POM_PACKAGING is not set, use "aar"

If required value is not set, say "You must set PROPERTY in gradle.properties file."