### PR TITLE
Disable doclint in JDK 8 Javadoc

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -95,6 +95,10 @@ afterEvaluate { project ->
     task androidJavadocs(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        
+        if (JavaVersion.current().isJava8Compatible()) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
     }
 
     task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {


### PR DESCRIPTION
Doclint was introduced in JDK 8 and checks Javadoc comments to conform W3C HTML 4.01 HTML. In my opinion it's a little bit to strict per default and crashes documentations, that worked well. This is an easy way to disable it per default. Maybe this should be optional with a gradle property. If you want, I can insert that as well.
