### PR TITLE
feat: Add support for non-android modules

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -93,8 +93,10 @@ afterEvaluate { project ->
     }
 
     task androidJavadocs(type: Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        if (hasAndroidPlugin()) {
+            source = android.sourceSets.main.java.srcDirs
+            classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+        }
     }
 
     task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
@@ -103,12 +105,25 @@ afterEvaluate { project ->
     }
 
     task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
-        from android.sourceSets.main.java.sourceFiles
+        if (hasAndroidPlugin()) {
+            from android.sourceSets.main.java.srcDirs
+            classifier = 'sources'
+        } else {
+            from sourceSets.main.allSource
+            classifier = 'sources'
+        }
     }
 
     artifacts {
         archives androidSourcesJar
         archives androidJavadocsJar
+    }
+}
+
+def hasAndroidPlugin() {
+    return getPlugins().inject(false) { a, b ->
+        def classStr = b.getClass().name
+        def isAndroid = ("com.android.build.gradle.LibraryPlugin" == classStr) || ("com.android.build.gradle.AppPlugin" == classStr)
+        a || isAndroid
     }
 }


### PR DESCRIPTION
Added support for non-android module packaging. 

Some modules in development are pure Java or pure groovy and will report errors likes:
`Could not get unknown property 'android' for task ':XXX:androidJavadocs' of type org.gradle.api.tasks.javadoc.Javadoc.`

