### PR TITLE
Fix gradle-mvn-push.gradle support for non-android libs

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -130,9 +130,12 @@ afterEvaluate { project ->
         }
     }
 
-    android.libraryVariants.all { variant ->
-        tasks.androidJavadocs.doFirst {
-            classpath += files(variant.javaCompileProvider.get().classpath.files.join(File.pathSeparator))
+    if (project.getPlugins().hasPlugin('com.android.application') ||
+            project.getPlugins().hasPlugin('com.android.library')) {
+        android.libraryVariants.all { variant ->
+            tasks.androidJavadocs.doFirst {
+                classpath += files(variant.javaCompileProvider.get().classpath.files.join(File.pathSeparator))
+            }
         }
     }
 


### PR DESCRIPTION
There was an "android" call not guarded by the plugins check. This made it not work for non-android projects.